### PR TITLE
fix: to avoid triggering system keyword errors

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -130,7 +130,7 @@ func (sc *SchemaSync) getSchemaDiff(alter *TableAlterData) []string {
 					alterSQL = "ADD " + el.Value.(string)
 				}
 			} else {
-				alterSQL = "ADD " + el.Value.(string) + " AFTER " + beforeFieldName
+        alterSQL = fmt.Sprintf("ADD %s AFTER `%s`", el.Value.(string), beforeFieldName)
 			}
 			beforeFieldName = el.Key.(string)
 		}

--- a/internal/testdata/result_1.sql
+++ b/internal/testdata/result_1.sql
@@ -4,6 +4,6 @@
 -- Comment :
 -- SQL :
 ALTER TABLE `user`
-ADD `register_time` timestamp NOT NULL AFTER email,
-ADD `password` varchar(1000) NOT NULL DEFAULT '' AFTER register_time,
-ADD `status` tinyint unsigned NOT NULL DEFAULT '0' AFTER password;
+ADD `register_time` timestamp NOT NULL AFTER `email`,
+ADD `password` varchar(1000) NOT NULL DEFAULT '' AFTER `register_time`,
+ADD `status` tinyint unsigned NOT NULL DEFAULT '0' AFTER `password`;

--- a/internal/testdata/result_2.sql
+++ b/internal/testdata/result_2.sql
@@ -4,8 +4,8 @@
 -- Comment :
 -- SQL :
 ALTER TABLE `user`
-ADD `register_time` timestamp NOT NULL AFTER email;
+ADD `register_time` timestamp NOT NULL AFTER `email`;
 ALTER TABLE `user`
-ADD `password` varchar(1000) NOT NULL DEFAULT '' AFTER register_time;
+ADD `password` varchar(1000) NOT NULL DEFAULT '' AFTER `register_time`;
 ALTER TABLE `user`
-ADD `status` tinyint unsigned NOT NULL DEFAULT '0' AFTER password;
+ADD `status` tinyint unsigned NOT NULL DEFAULT '0' AFTER `password`;


### PR DESCRIPTION
Due to an inadvertent incident, the developers defined a table structure field name as "numeric," which led to SQL syntax errors during synchronization using the tool. I found `AFTER` field name without ` in xxx.sql.

Thanks for your pretty cool tool.