### PR TITLE
fix:  occur db_index parse failed when sql_mode includes ANSI_QUOTES

### DIFF
--- a/internal/schema.go
+++ b/internal/schema.go
@@ -76,12 +76,20 @@ func ParseSchema(schema string) *MySchema {
 		if len(line) == 0 {
 			continue
 		}
+
 		line = strings.TrimRight(line, ",")
-		if line[0] == '`' {
+		switch line[0] {
+		case '`':
 			index := strings.Index(line[1:], "`")
 			name := line[1 : index+1]
 			mys.Fields.Set(name, line)
-		} else {
+
+		case '"':
+			index := strings.Index(line[1:], "\"")
+			name := line[1 : index+1]
+			mys.Fields.Set(name, line)
+
+		default:
 			idx := parseDbIndexLine(line)
 			if idx == nil {
 				continue

--- a/internal/schema_test.go
+++ b/internal/schema_test.go
@@ -54,6 +54,31 @@ func TestParseSchema(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "case 2",
+			args: args{
+				schema: testLoadFile("testdata/user_4.sql"),
+			},
+			want: &MySchema{
+				Fields: (func() *orderedmap.OrderedMap {
+					m := orderedmap.NewOrderedMap()
+					// 不会检查 value
+					m.Set("id", "\"id\" bigint unsigned NOT NULL AUTO_INCREMENT,")
+					m.Set("email", "\"email\" varchar(1000) NOT NULL DEFAULT \"\",")
+					m.Set("register_time", "\"register_time\" timestamp NOT NULL,")
+					m.Set("password", "\"password\" varchar(1000) NOT NULL DEFAULT \"\",")
+					m.Set("status", "\"status\" tinyint unsigned NOT NULL DEFAULT \"0\",")
+					return m
+				})(),
+				IndexAll: map[string]*DbIndex{
+					"PRIMARY KEY": {
+						Name:      "PRIMARY KEY",
+						SQL:       "PRIMARY KEY (\"id\")",
+						IndexType: indexTypePrimary,
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/testdata/user_4.sql
+++ b/internal/testdata/user_4.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "user" (
+    "id" bigint unsigned NOT NULL AUTO_INCREMENT,
+    "email" varchar(1000) NOT NULL DEFAULT "",
+    "register_time" timestamp NOT NULL,
+    "password" varchar(1000) NOT NULL DEFAULT "",
+    "status" tinyint unsigned NOT NULL DEFAULT "0",
+    PRIMARY KEY ("id")
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb3


### PR DESCRIPTION
I get an error about `db_index parse failed`. Exec `show create table xxx` if sql_mode includes `ANSI_QUOTES`, keywords are wrapped ", and not `.

- Case sql_mode include `ANSI_QUOTES`
```sql
CREATE TABLE "users" (
  "id" int NOT NULL AUTO_INCREMENT,
  "name" varchar(25) DEFAULT NULL,
  "age" int DEFAULT NULL,
  "created_at" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  "updated_at" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY ("id")
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
``` 
- Case sql_mode not include `ANSI_QUOTES`
```sql
CREATE TABLE `users` (
  `id` int NOT NULL AUTO_INCREMENT,
  `name` varchar(25) DEFAULT NULL,
  `age` int DEFAULT NULL,
  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
```

